### PR TITLE
Add github action to run tests against PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,9 +25,11 @@ jobs:
     - name: Set up MySQL
       run: |
         sudo systemctl start mysql.service
+        mysql -uroot -e "CREATE DATABASE notifications_test;"
 
     - name: Test
       run: |
+        export DATABASE_URL="root:root@localhost:3306/notifications_test"
         go install github.com/onsi/ginkgo/v2/ginkgo@v2
         ginkgo version
         bin/test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,26 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Tests
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        check-latest: true
+
+    - name: Test
+      run: bin/test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up MySQL
       run: |
         sudo systemctl start mysql.service
-        mysql -uroot -e "CREATE DATABASE notifications_test;"
+        mysql -uroot -proot -e "CREATE DATABASE notifications_test;"
 
     - name: Test
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,10 @@ jobs:
         go-version-file: go.mod
         check-latest: true
 
+    - name: Set up MySQL
+      run: |
+        sudo systemctl start mysql.service
+
     - name: Test
       run: |
         go install github.com/onsi/ginkgo/v2/ginkgo@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,4 +23,7 @@ jobs:
         check-latest: true
 
     - name: Test
-      run: bin/test
+      run: |
+        go install github.com/onsi/ginkgo/v2/ginkgo@v2
+        ginkgo version
+        bin/test


### PR DESCRIPTION
This is a companion to https://github.com/cloudfoundry/notifications/pull/41 .  When we turn on autobumps with dependabot, we want to be confident that the bumps actually work before merging.  This will run the `bin/test` script to gain that confidence.

To see an example of this action, see the test pr I did in my fork https://github.com/moleske/notifications/pull/1/checks